### PR TITLE
fix : Update Dockerfile > `podman` build failed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN npm install -g --unsafe-perm node-red \
 
 # --- Installer dépendances Python
 COPY requirements.txt /app/requirements.txt
-RUN pip3 install --no-cache-dir -r /app/requirements.txt
+RUN pip3 install --no-cache-dir --break-system-packages -r /app/requirements.txt
 
 # --- Structure du projet
 WORKDIR /app


### PR DESCRIPTION
Bonjour, sans ce fix, on arrive pas à builder l'image : 

```sh
podman build -t nodred-modbus .
```
Et du coup, ça builde (mais je ne sais pas si ça marche) : 

<img width="829" height="173" alt="image" src="https://github.com/user-attachments/assets/c30b89bc-41f2-4625-bbbb-f28b07edfbf2" />

De vôtre côté arrivez-vous à builder l'image ? Si oui, quelles sont les instructions à passer svp ?